### PR TITLE
Fix queries only looking for elements on primary site ID

### DIFF
--- a/src/controllers/TranslateController.php
+++ b/src/controllers/TranslateController.php
@@ -172,7 +172,8 @@ class TranslateController extends \craft\web\Controller {
 							'translateToSiteId' => $translate_to_site_id,
 							'enabledFields'     => $_enabledFields,
 							'instructions'      => $instructions,
-							'translationId'     => $translateRecord->id
+							'translationId'     => $translateRecord->id,
+                            'siteId'            => $primarySiteId,
 						] ), 10 + $indexLanguage, $this->_getDelay( $indexLanguage, $index ), $this->_getTTR()
 					);
 					if ( $jobId ) {
@@ -423,7 +424,8 @@ class TranslateController extends \craft\web\Controller {
 					'instructions'      => $instructions,
 					'translationId'     => $translateRecord->id,
 					'translateSlugs'    => $translateSlugs,
-					'type'              => 'category'
+					'type'              => 'category',
+                    'siteId'            => $siteId,
 				] ), 10 + $index, $this->_getDelay( $index ), $this->_getTTR()
 			);
 			$translateRecord->entriesSubmitted = 1;
@@ -519,7 +521,8 @@ class TranslateController extends \craft\web\Controller {
 					'instructions'      => $instructions,
 					'translationId'     => $translateRecord->id,
 					'translateSlugs'    => $translateSlugs,
-					'type'              => 'asset'
+					'type'              => 'asset',
+                    'siteId'            => $siteId,
 				] ), 10 + $index, $this->_getDelay( $index ), $this->_getTTR()
 			);
 			$translateRecord->entriesSubmitted = 1;
@@ -630,7 +633,8 @@ class TranslateController extends \craft\web\Controller {
 					'instructions'      => $instructions,
 					'translationId'     => $translateRecord->id,
 					'translateSlugs'    => $translateSlugs,
-					'type'              => 'product'
+					'type'              => 'product',
+                    'siteId'            => $siteId,
 				] ), 10 + $index, $this->_getDelay( $index ), $this->_getTTR()
 			);
 			$translateRecord->entriesSubmitted = 1;

--- a/src/queue/translateEntries.php
+++ b/src/queue/translateEntries.php
@@ -68,14 +68,12 @@ class translateEntries extends BaseJob {
 		$this->setProgress( $this->_queue, 0 );
 
 		foreach ( $this->entriesIds as $id ) {
-			$entry    = Craft::$app->entries->getEntryById( $id, $this->siteId );
-			$category = Category::findOne( $id );
-			$asset    = Asset::findOne( $id );
-			$product    = null;
-			if(Translate::isCommerceInstalled()){
-				$product    = Product::findOne( $id );
-			}
-
+            $entry    = Craft::$app->entries->getEntryById( $id, $this->siteId );
+            $category = Category::find()->id( $id )->siteId( $this->siteId )->one();
+            $asset    = Asset::find()->id( $id )->siteId( $this->siteId )->one();
+            $product  = Translate::isCommerceInstalled()
+                ? Product::find()->id( $id )->siteId( $this->siteId )->one()
+                : null;
 
 			if ( $entry ) {
 				BuddyPlugin::getInstance()->translate->translateEntry(


### PR DESCRIPTION
`findOne()` only looks for the element ID at the primary site, so it won't find elements that aren't accessible for the primary site